### PR TITLE
Fix ls command raising traceback

### DIFF
--- a/commands/ls.py
+++ b/commands/ls.py
@@ -8,10 +8,11 @@ def run(args: str, ro_path):
     path = ro_path
     if len(args.split(" ")) > 1:
         path = " ".join(args.split(" ")[1:])
-
-    for files in os.listdir(path):
-        print(Fore.CYAN + '-' + files)
-
+    try:
+        for files in os.listdir(path):
+            print(Fore.CYAN + '-' + files)
+    except:
+        print("Can't list directory: "+path)
 
 # must have
 def constructor():


### PR DESCRIPTION
![IMG_1222](https://user-images.githubusercontent.com/60709927/221373959-3760f1e7-291a-46c5-877b-878ae48b1d3c.jpeg)

The command now says `Can’t list directory: example_directory`. The shell will also now not exit when it has this issue.